### PR TITLE
Set archive to false for pawn.json

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -6,13 +6,13 @@
         {
             "name": "^ColAndreas_static.so$",
             "platform": "linux",
-            "archive": true,
+            "archive": false,
             "plugins": ["colandreas_static.so"]
         },
         {
             "name": "^ColAndreas.dll$",
             "platform": "windows",
-            "archive": true,
+            "archive": false,
             "plugins": ["ColAndreas.dll"]
         }
     ],


### PR DESCRIPTION
The release files for this repo are not in any archived file, now in your `pawn.json` file you have `archive` set to true, so sampctl is not able to properly extract your resources and therefore developers can not use your plugin with sampctl.

My PR will fix this issue: https://github.com/Southclaws/sampctl/issues/257