### PR TITLE
Add SA-MP 0.3DL custom models support

### DIFF
--- a/Server/include/colandreas.inc
+++ b/Server/include/colandreas.inc
@@ -325,6 +325,23 @@ native CA_RayCastLineAngleEx(Float:StartX, Float:StartY, Float:StartZ, Float:End
 
 /**--------------------------------------------------------------------------**\
 <summary>
+	CA_LoadFromDff
+</summary>
+<param name="newid">Custom model id to be added to col. pool</param>
+<param name="dffFileName">Dff file path you want to load its collision</param>
+<returns>
+	-1 if plugin couldn't find/open file (relatd to permissions or wrong path)
+	0 if dff file had no collision or corrupted data
+	1 if loading dff file and reading collision data was successful
+</returns>
+<remarks>
+	Loads collision from given dff file to support SA-MP 0.3DL custom models.
+</remarks>
+\**--------------------------------------------------------------------------**/
+native CA_LoadFromDff(newid, const dffFileName[]);
+
+/**--------------------------------------------------------------------------**\
+<summary>
 	CA_CreateObject
 </summary>
 <param name="modelid">The collision model to create</param>

--- a/src/ColAndreas.cpp
+++ b/src/ColAndreas.cpp
@@ -80,6 +80,7 @@ AMX_NATIVE_INFO PluginNatives[] =
 	{ "CA_RayCastReflectionVector", ColAndreasNatives::CA_RayCastReflectionVector },
 	{ "CA_RayCastLineNormal", ColAndreasNatives::CA_RayCastLineNormal },
 	{ "CA_ContactTest", ColAndreasNatives::CA_ContactTest },
+	{ "CA_LoadFromDff", ColAndreasNatives::CA_LoadFromDff },
 	{ "CA_CreateObject", ColAndreasNatives::CA_CreateObject },
 	{ "CA_DestroyObject", ColAndreasNatives::CA_DestroyObject },
 	{ "CA_IsValidObject", ColAndreasNatives::CA_IsValidObject },

--- a/src/ColAndreasDatabaseReader.cpp
+++ b/src/ColAndreasDatabaseReader.cpp
@@ -1,16 +1,16 @@
 #include "ColAndreasDatabaseReader.h"
 #include "ColAndreas.h"
 
-CollisionModelstructure* CollisionModels;
+std::map<uint16_t, CollisionModelstructure> CollisionModels;
 ItemPlacementstructure* ModelPlacements;
 
 uint16_t ModelCount = 0;
 uint32_t IPLCount = 0;
-uint16_t ModelRef[20000];
+std::map<int32_t, uint16_t> ModelRef;
 
 void DeleteCollisionData()
 {
-	delete CollisionModels;
+	CollisionModels.clear();
 	delete ModelPlacements;
 }
 
@@ -49,7 +49,6 @@ bool ReadColandreasDatabaseFile(std::string FileLocation)
 				GetBytes(buffer, IPLCount, FileIndex, 4);
 
 				if (ModelCount > 0) {
-					CollisionModels = new CollisionModelstructure[ModelCount];
 
 					for (uint16_t i = 0; i < ModelCount; i++) {
 						GetBytes(buffer, CollisionModels[i].Modelid, FileIndex, 2);
@@ -96,6 +95,11 @@ bool ReadColandreasDatabaseFile(std::string FileLocation)
 
 				// Set model ref default values
 				for (int i = 0; i < 20000; i++)
+				{
+					ModelRef[i] = 65535;
+				}
+
+				for (int i = -1000; i < -30000; i++)
 				{
 					ModelRef[i] = 65535;
 				}

--- a/src/ColAndreasDatabaseReader.h
+++ b/src/ColAndreasDatabaseReader.h
@@ -77,6 +77,7 @@ typedef struct {
 typedef struct
 {
 	uint16_t Modelid;
+	int16_t CustomModelid;
 
 	//define our counts
 	uint16_t SphereCount;

--- a/src/ColAndreasDatabaseReader.h
+++ b/src/ColAndreasDatabaseReader.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <fstream>
 #include <cstring>
+#include <map>
 
 using namespace std;
 
@@ -108,11 +109,11 @@ returns a boolean true if function suceeded, otherwise false.
 */
 
 bool ReadColandreasDatabaseFile(std::string FileLocation);
-extern CollisionModelstructure* CollisionModels;
+extern std::map<uint16_t, CollisionModelstructure> CollisionModels;
 extern ItemPlacementstructure* ModelPlacements;
 extern uint16_t ModelCount;
 extern uint32_t IPLCount;
-extern uint16_t ModelRef[20000];
+extern std::map<int32_t, uint16_t> ModelRef;
 
 #endif 
 

--- a/src/ColObject.cpp
+++ b/src/ColObject.cpp
@@ -94,7 +94,7 @@ bool LoadCollisionData(btDynamicsWorld* collisionWorld)
 }
 
 
-ColAndreasMapObject::ColAndreasMapObject(uint16_t modelid, const btQuaternion& objectRot, const btVector3& objectPos, btDynamicsWorld* world)
+ColAndreasMapObject::ColAndreasMapObject(int32_t modelid, const btQuaternion& objectRot, const btVector3& objectPos, btDynamicsWorld* world)
 {
 	colindex = ModelRef[modelid];
 
@@ -275,7 +275,7 @@ int ObjectManager::setObjectRotation(const uint16_t index, btQuaternion& rotatio
 }
 
 
-int ObjectManager::getBoundingSphere(uint16_t modelid, btVector3& center, btScalar& radius)
+int ObjectManager::getBoundingSphere(int32_t modelid, btVector3& center, btScalar& radius)
 {
 	uint16_t colindex = ModelRef[modelid];
 
@@ -296,7 +296,7 @@ int ObjectManager::getBoundingSphere(uint16_t modelid, btVector3& center, btScal
 }
 
 
-int ObjectManager::getBoundingBox(uint16_t modelid, btVector3& min, btVector3& max)
+int ObjectManager::getBoundingBox(int32_t modelid, btVector3& min, btVector3& max)
 {
 	uint16_t colindex = ModelRef[modelid];
 	btTransform t;
@@ -375,7 +375,7 @@ void InitCollisionMap(btDynamicsWorld* collisionWorld, RemovedBuildingManager* r
 	}
 }
 
-uint16_t GetModelRef(uint16_t model) 
+uint16_t GetModelRef(int32_t model)
 {
 	if (model <= 20000 && ModelRef[model] != 65535)
 		return ModelRef[model];

--- a/src/ColObject.h
+++ b/src/ColObject.h
@@ -59,7 +59,7 @@ private:
 class ColAndreasMapObject
 {
 public:
-	ColAndreasMapObject(uint16_t modelid, const btQuaternion& objectRot, const btVector3& objectPos, btDynamicsWorld* world);
+	ColAndreasMapObject(int32_t modelid, const btQuaternion& objectRot, const btVector3& objectPos, btDynamicsWorld* world);
 	~ColAndreasMapObject();
 	void setMapObjectPosition(btVector3& position);
 	void setMapObjectRotation(btQuaternion& rotation);
@@ -95,8 +95,8 @@ public:
 	int validObjectManager(const uint16_t index);
 	int setObjectPosition(const uint16_t index, btVector3& position);
 	int setObjectRotation(const uint16_t index, btQuaternion& rotation);
-	int getBoundingSphere(uint16_t modelid, btVector3& center, btScalar& radius);
-	int getBoundingBox(uint16_t modelid, btVector3& min, btVector3& max);	      
+	int getBoundingSphere(int32_t modelid, btVector3& center, btScalar& radius);
+	int getBoundingBox(int32_t modelid, btVector3& min, btVector3& max);
 	int setExtraID(const uint16_t index, int type, int data);
 	int getExtraID(const uint16_t index, int type);
 private:
@@ -118,7 +118,7 @@ private:
 
 bool LoadCollisionData(btDynamicsWorld* collisionWorld);
 void InitCollisionMap(btDynamicsWorld* collisionWorld, RemovedBuildingManager* removeManager);
-uint16_t GetModelRef(uint16_t model);
+uint16_t GetModelRef(int32_t model);
 
 // Pointer reference
 extern std::vector <ColAndreasColObject*> colObjects;

--- a/src/DynamicWorld.cpp
+++ b/src/DynamicWorld.cpp
@@ -67,7 +67,7 @@ void ColAndreasWorld::QuatToEuler(btQuaternion& rotation, btVector3& result)
 	result.setZ((-atan2(2 * ((rotation.getX() * rotation.getY()) + (rotation.getW() * rotation.getZ())), (rotation.getW() * rotation.getW()) + (rotation.getX() * rotation.getX()) - (rotation.getY() * rotation.getY()) - (rotation.getZ() * rotation.getZ())) * RADIAN_TO_DEG) );
 }
 
-int ColAndreasWorld::performRayTest(const btVector3& Start, const btVector3& End, btVector3& Result, uint16_t& model)
+int ColAndreasWorld::performRayTest(const btVector3& Start, const btVector3& End, btVector3& Result, int32_t& model)
 {
 	btCollisionWorld::ClosestRayResultCallback RayCallback(Start, End);
 
@@ -126,7 +126,7 @@ int ColAndreasWorld::performRayTestID(const btVector3& Start, const btVector3& E
 	return 0;
 }
 
-int ColAndreasWorld::performRayTestEx(const btVector3& Start, const btVector3& End, btVector3& Result, btQuaternion& Rotation, btVector3& Position, uint16_t& model)
+int ColAndreasWorld::performRayTestEx(const btVector3& Start, const btVector3& End, btVector3& Result, btQuaternion& Rotation, btVector3& Position, int32_t& model)
 {
 	btCollisionWorld::ClosestRayResultCallback RayCallback(Start, End);
 
@@ -144,7 +144,7 @@ int ColAndreasWorld::performRayTestEx(const btVector3& Start, const btVector3& E
 }
 
 
-int ColAndreasWorld::performRayTestAngle(const btVector3& Start, const btVector3& End, btVector3& Result, btScalar& RX, btScalar& RY, btScalar& RZ, uint16_t& model)
+int ColAndreasWorld::performRayTestAngle(const btVector3& Start, const btVector3& End, btVector3& Result, btScalar& RX, btScalar& RY, btScalar& RZ, int32_t& model)
 {
 	btCollisionWorld::ClosestRayResultCallback RayCallback(Start, End);
 
@@ -164,7 +164,7 @@ int ColAndreasWorld::performRayTestAngle(const btVector3& Start, const btVector3
 	return 0;
 }
 
-int ColAndreasWorld::performRayTestAngleEx(const btVector3& Start, const btVector3& End, btVector3& Result, btScalar& RX, btScalar& RY, btScalar& RZ, btQuaternion& Rotation, btVector3& Position, uint16_t& model)
+int ColAndreasWorld::performRayTestAngleEx(const btVector3& Start, const btVector3& End, btVector3& Result, btScalar& RX, btScalar& RY, btScalar& RZ, btQuaternion& Rotation, btVector3& Position, int32_t& model)
 {
 	btCollisionWorld::ClosestRayResultCallback RayCallback(Start, End);
 
@@ -216,7 +216,7 @@ int ColAndreasWorld::performRayTestAll(const btVector3& Start, const btVector3& 
 }
 
 // Return reflection vector
-int ColAndreasWorld::performRayTestReflection(const btVector3& Start, const btVector3& End, btVector3& Position, btVector3& Result, uint16_t& model)
+int ColAndreasWorld::performRayTestReflection(const btVector3& Start, const btVector3& End, btVector3& Position, btVector3& Result, int32_t& model)
 {
 	btCollisionWorld::ClosestRayResultCallback RayCallback(Start, End);
 
@@ -239,7 +239,7 @@ int ColAndreasWorld::performRayTestReflection(const btVector3& Start, const btVe
 }
 
 
-int ColAndreasWorld::performRayTestNormal(const btVector3& Start, const btVector3& End, btVector3& Result, btVector3& Normal, uint16_t& model)
+int ColAndreasWorld::performRayTestNormal(const btVector3& Start, const btVector3& End, btVector3& Result, btVector3& Normal, int32_t& model)
 {
 	btCollisionWorld::ClosestRayResultCallback RayCallback(Start, End);
 
@@ -255,7 +255,7 @@ int ColAndreasWorld::performRayTestNormal(const btVector3& Start, const btVector
 	return 0;
 }
 
-int ColAndreasWorld::performContactTest(uint16_t modelid, btVector3& objectPos, btQuaternion& objectRot)
+int ColAndreasWorld::performContactTest(int32_t modelid, btVector3& objectPos, btQuaternion& objectRot)
 {
 	ContactCollisionSensor callback;
 	
@@ -281,7 +281,7 @@ void ColAndreasWorld::colandreasInitMap()
 	InitCollisionMap(this->dynamicsWorld, this->removedManager);
 }
 
-uint16_t ColAndreasWorld::createColAndreasMapObject(uint16_t addtomanager, uint16_t modelid, const btQuaternion& objectRot, const btVector3& objectPos)
+uint16_t ColAndreasWorld::createColAndreasMapObject(uint16_t addtomanager, int32_t modelid, const btQuaternion& objectRot, const btVector3& objectPos)
 {
 	ColAndreasMapObject* mapObject = new ColAndreasMapObject(modelid, objectRot, objectPos, this->dynamicsWorld);
 	if (addtomanager)
@@ -292,7 +292,7 @@ uint16_t ColAndreasWorld::createColAndreasMapObject(uint16_t addtomanager, uint1
 	return -1;
 }
 
-uint16_t ColAndreasWorld::getModelRef(uint16_t model)
+uint16_t ColAndreasWorld::getModelRef(int32_t model)
 {
 	return GetModelRef(model);
 }

--- a/src/DynamicWorld.h
+++ b/src/DynamicWorld.h
@@ -40,19 +40,19 @@ public:
 	void QuatToEuler(btQuaternion& rotation, btVector3& result);
 	void setMyExtraID(uint16_t index, int type, int data);
 	int getMyExtraID(uint16_t index, int type);
-	int performRayTest(const btVector3& Start, const btVector3& End, btVector3& Result, uint16_t& model);
+	int performRayTest(const btVector3& Start, const btVector3& End, btVector3& Result, int32_t& model);
 	int performRayTestExtraID(const btVector3& Start, const btVector3& End, btVector3& Result, const int type, uint16_t& data);
 	int performRayTestID(const btVector3& Start, const btVector3& End, btVector3& Result, uint16_t& index);
-	int performRayTestEx(const btVector3& Start, const btVector3& End, btVector3& Result, btQuaternion& Rotation, btVector3& Position, uint16_t& model);
-	int performRayTestAngle(const btVector3& Start, const btVector3& End, btVector3& Result, btScalar& RX, btScalar& RY, btScalar& RZ, uint16_t& model);
-	int performRayTestAngleEx(const btVector3& Start, const btVector3& End, btVector3& Result, btScalar& RX, btScalar& RY, btScalar& RZ, btQuaternion& Rotation, btVector3& Position, uint16_t& model);
+	int performRayTestEx(const btVector3& Start, const btVector3& End, btVector3& Result, btQuaternion& Rotation, btVector3& Position, int32_t& model);
+	int performRayTestAngle(const btVector3& Start, const btVector3& End, btVector3& Result, btScalar& RX, btScalar& RY, btScalar& RZ, int32_t& model);
+	int performRayTestAngleEx(const btVector3& Start, const btVector3& End, btVector3& Result, btScalar& RX, btScalar& RY, btScalar& RZ, btQuaternion& Rotation, btVector3& Position, int32_t& model);
 	int performRayTestAll(const btVector3& Start, const btVector3& End, btAlignedObjectArray < btVector3 >& Result, int ModelIDs[], int size);
-	int performRayTestReflection(const btVector3& Start, const btVector3& End, btVector3& Position, btVector3& Result, uint16_t& model);
-	int performRayTestNormal(const btVector3& Start, const btVector3& End, btVector3& Result, btVector3& Normal, uint16_t& model);
-	int performContactTest(uint16_t modelid, btVector3& objectPos, btQuaternion& objectRot);
+	int performRayTestReflection(const btVector3& Start, const btVector3& End, btVector3& Position, btVector3& Result, int32_t& model);
+	int performRayTestNormal(const btVector3& Start, const btVector3& End, btVector3& Result, btVector3& Normal, int32_t& model);
+	int performContactTest(int32_t modelid, btVector3& objectPos, btQuaternion& objectRot);
 
-	uint16_t createColAndreasMapObject(uint16_t addtomanager, uint16_t modelid, const btQuaternion& objectRot, const btVector3& objectPos);
-	uint16_t getModelRef(uint16_t model);
+	uint16_t createColAndreasMapObject(uint16_t addtomanager, int32_t modelid, const btQuaternion& objectRot, const btVector3& objectPos);
+	uint16_t getModelRef(int32_t model);
 	void colandreasInitMap();
 	bool loadCollisionData();
 

--- a/src/Natives.cpp
+++ b/src/Natives.cpp
@@ -458,7 +458,7 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_GetModelBoundingSphere(AMX *amx, cell
 {
 	int32_t modelid = static_cast<int32_t>(params[1]);
 	
-	if (modelid >= 0 && modelid < 20000)
+	if ((modelid >= 0 && modelid < 20000) || (modelid >= -1000 && modelid < -30000))
 	{
 		btScalar Radius;
 		btVector3 Center;
@@ -487,7 +487,7 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_GetModelBoundingBox(AMX *amx, cell *p
 {
 	int32_t modelid = static_cast<int32_t>(params[1]);
 	
-	if (modelid >= 0 && modelid < 20000)
+	if ((modelid >= 0 && modelid < 20000) || (modelid >= -1000 && modelid < -30000))
 	{
 		btVector3 Min;
 		btVector3 Max;

--- a/src/Natives.cpp
+++ b/src/Natives.cpp
@@ -38,7 +38,7 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_RayCastLine(AMX *amx, cell *params)
 	btVector3 Start = btVector3(btScalar(amx_ctof(params[1]) + 0.00001), btScalar(amx_ctof(params[2]) + 0.00001), btScalar(amx_ctof(params[3]) + 0.00001));
 	btVector3 End = btVector3(btScalar(amx_ctof(params[4])), btScalar(amx_ctof(params[5])), btScalar(amx_ctof(params[6])));
 	btVector3 Result;
-	uint16_t Model = 0;
+	int32_t Model = 0;
 
 	if (collisionWorld->performRayTest(Start, End, Result, Model))
 	{
@@ -121,7 +121,7 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_RayCastLineEx(AMX *amx, cell *params)
 	btVector3 Position;
 	btQuaternion Rotation;
 	btVector3 Result;
-	uint16_t Model = 0;
+	int32_t Model = 0;
 
 	if (collisionWorld->performRayTestEx(Start, End, Result, Rotation, Position, Model))
 	{
@@ -164,7 +164,7 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_RayCastLineAngle(AMX *amx, cell *para
 	btScalar RX;
 	btScalar RY;
 	btScalar RZ;
-	uint16_t model = 0;
+	int32_t model = 0;
 
 	if (collisionWorld->performRayTestAngle(Start, End, Result, RX, RY, RZ, model))
 	{
@@ -202,7 +202,7 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_RayCastLineAngleEx(AMX *amx, cell *pa
 	btScalar RX;
 	btScalar RY;
 	btScalar RZ;
-	uint16_t Model = 0;
+	int32_t Model = 0;
 
 	if (collisionWorld->performRayTestAngleEx(Start, End, Result, RX, RY, RZ, ObjectRotation, ObjectPosition, Model))
 	{
@@ -304,7 +304,7 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_CreateObject(AMX *amx, cell *params)
 		return -1;
 	}
 	
-	uint16_t modelid = static_cast<uint16_t>(params[1]);
+	int32_t modelid = static_cast<int32_t>(params[1]);
 	uint16_t addtomanager = static_cast<uint16_t>(params[8]);
 
 	if (collisionWorld->getModelRef(modelid) != 65535)
@@ -424,7 +424,7 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_SetObjectRot(AMX *amx, cell *params)
 
 cell AMX_NATIVE_CALL ColAndreasNatives::CA_GetModelBoundingSphere(AMX *amx, cell *params)
 {
-	uint16_t modelid = static_cast<uint16_t>(params[1]);
+	int32_t modelid = static_cast<int32_t>(params[1]);
 	
 	if (modelid >= 0 && modelid < 20000)
 	{
@@ -453,7 +453,7 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_GetModelBoundingSphere(AMX *amx, cell
 
 cell AMX_NATIVE_CALL ColAndreasNatives::CA_GetModelBoundingBox(AMX *amx, cell *params)
 {
-	uint16_t modelid = static_cast<uint16_t>(params[1]);
+	int32_t modelid = static_cast<int32_t>(params[1]);
 	
 	if (modelid >= 0 && modelid < 20000)
 	{
@@ -507,7 +507,7 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_RayCastReflectionVector(AMX *amx, cel
 	btVector3 End = btVector3(btScalar(amx_ctof(params[4])), btScalar(amx_ctof(params[5])), btScalar(amx_ctof(params[6])));
 	btVector3 Result;
 	btVector3 Position;
-	uint16_t model;
+	int32_t model;
 
 	if (collisionWorld->performRayTestReflection(Start, End, Position, Result, model))
 	{
@@ -545,7 +545,7 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_RayCastLineNormal(AMX *amx, cell *par
 	btVector3 End = btVector3(btScalar(amx_ctof(params[4])), btScalar(amx_ctof(params[5])), btScalar(amx_ctof(params[6])));
 	btVector3 Result;
 	btVector3 Position;
-	uint16_t model;
+	int32_t model;
 
 	if (collisionWorld->performRayTestNormal(Start, End, Position, Result, model))
 	{
@@ -573,7 +573,7 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_RayCastLineNormal(AMX *amx, cell *par
 
 cell AMX_NATIVE_CALL ColAndreasNatives::CA_ContactTest(AMX *amx, cell *params)
 {
-	uint16_t modelid = static_cast<uint16_t>(params[1]);
+	int32_t modelid = static_cast<int32_t>(params[1]);
 	
 	btVector3 position = btVector3(amx_ctof(params[2]), amx_ctof(params[3]), amx_ctof(params[4]));
 	btVector3 rotation = btVector3(amx_ctof(params[5]), amx_ctof(params[6]), amx_ctof(params[7]));

--- a/src/Natives.cpp
+++ b/src/Natives.cpp
@@ -321,10 +321,11 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_LoadFromDff(AMX *amx, cell *params)
 	if (dffData.read(file, modelid))
 	{
 		logprintf("ColAndreas: Loaded custom model collision. ID: %d, Model Name: %s", modelid, _dffModelName);
+		return 1;
 	}
 
-	// Model had no collision
-	return -1;
+	logprintf("ColAndreas: Unable to load collision from given dff file (Corrupted data or no collision). ID: %d, Model Name: %s", modelid, _dffModelName);
+	return 0;
 }
 
 cell AMX_NATIVE_CALL ColAndreasNatives::CA_CreateObject(AMX *amx, cell *params)

--- a/src/Natives.cpp
+++ b/src/Natives.cpp
@@ -1,5 +1,6 @@
 #include "Natives.h"
 #include "DynamicWorld.h"
+#include <renderware.h>
 
 // Maximum number of raycasts
 #define MAX_MULTICAST_SIZE 99
@@ -294,6 +295,36 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_RayCastMultiLine(AMX *amx, cell *para
 		return -1;
 	}
 	return 0;
+}
+
+cell AMX_NATIVE_CALL ColAndreasNatives::CA_LoadFromDff(AMX *amx, cell *params)
+{
+	if (!colDataLoaded)
+	{
+		logprintf("ERROR: CA_LoadFromDff : ColAndreas.cadb not loaded; you need it even if you only want custom models collision");
+		return -1;
+	}
+
+	int32_t modelid = static_cast<int32_t>(params[1]);
+	char* _dffModelName;
+	amx_StrParam(amx, params[2], _dffModelName);
+	std::string dffModelName = std::string("models/") + _dffModelName;
+
+	rw::Clump dffData;
+	ifstream file(dffModelName, ios::binary);
+	if (file.fail()) 
+	{
+		logprintf("ERROR: CA_LoadFromDff: File %s not found in models directory.", _dffModelName);
+		return -1;
+	}
+
+	if (dffData.read(file, modelid))
+	{
+		logprintf("ColAndreas: Loaded custom model collision. ID: %d, Model Name: %s", modelid, _dffModelName);
+	}
+
+	// Model had no collision
+	return -1;
 }
 
 cell AMX_NATIVE_CALL ColAndreasNatives::CA_CreateObject(AMX *amx, cell *params)

--- a/src/Natives.h
+++ b/src/Natives.h
@@ -14,6 +14,7 @@ public:
 	static cell AMX_NATIVE_CALL CA_RayCastLineAngle(AMX *amx, cell *params);
 	static cell AMX_NATIVE_CALL CA_RayCastReflectionVector(AMX *amx, cell *params);
 	static cell AMX_NATIVE_CALL CA_RayCastLineNormal(AMX *amx, cell *params);
+	static cell AMX_NATIVE_CALL CA_LoadFromDff(AMX *amx, cell *params);
 	static cell AMX_NATIVE_CALL CA_CreateObject(AMX *amx, cell *params);
 	static cell AMX_NATIVE_CALL CA_DestroyObject(AMX *amx, cell *params);
 	static cell AMX_NATIVE_CALL CA_IsValidObject(AMX *amx, cell *params);

--- a/src/dffread.cpp
+++ b/src/dffread.cpp
@@ -1,0 +1,298 @@
+#include <cmath>
+#include "ColAndreas.h"
+#include "DynamicWorld.h"
+#include <renderware.h>
+using namespace std;
+
+namespace rw {
+
+	char *filename;
+
+	/*
+	 * Clump
+	 */
+
+	bool Clump::read(istream& rw, int32_t modelid)
+	{
+		iModelId = modelid;
+		HeaderInfo header;
+		header.read(rw);
+
+		READ_HEADER(CHUNK_STRUCT);
+		uint32 numAtomics = readUInt32(rw);
+		uint32 numLights = 0;
+		if (header.length == 0xC) {
+			numLights = readUInt32(rw);
+			rw.seekg(4, ios::cur);
+		}
+
+		// skip framelist
+		READ_HEADER(CHUNK_FRAMELIST);
+		rw.seekg(header.length, ios::cur);
+
+		// skip geometry list
+		READ_HEADER(CHUNK_GEOMETRYLIST);
+		rw.seekg(header.length, ios::cur);
+
+		// skip atomic
+		READ_HEADER(CHUNK_ATOMIC);
+		rw.seekg(header.length, ios::cur);
+
+		// skip lights
+		for (uint32 i = 0; i < numLights; i++) {
+			READ_HEADER(CHUNK_STRUCT);
+			rw.seekg(header.length, ios::cur);
+		}
+
+		hasCollision = false;
+		return readExtension(rw);
+	}
+
+	bool Clump::readExtension(istream &rw)
+	{
+		bool result = false;
+		HeaderInfo header;
+
+		READ_HEADER(CHUNK_EXTENSION);
+		streampos end = rw.tellg();
+		end += header.length;
+
+		while (rw.tellg() < end) {
+			header.read(rw);
+			switch (header.type) {
+			case CHUNK_SAMPCOLLISION:
+				hasCollision = true;
+				result = collision.read(rw, iModelId);
+				break;
+			default:
+				return result;
+			}
+		}
+		return result;
+	}
+
+	bool Collision::read(std::istream &rw, int32_t modelid)
+	{
+		ColHeader fileHeader;
+		std::streamoff beginPos = rw.tellg();
+		rw.read((char*)&fileHeader, sizeof(fileHeader));
+		if (rw.gcount() == sizeof(fileHeader) && !strncmp(fileHeader.validator, "COL3", 4))
+		{
+			rw.seekg(40, std::ios::cur);
+			if (ModelCount > 0)
+			{
+				uint16_t i = ModelCount;
+				ModelCount++;
+
+				CollisionModels[i].CustomModelid = modelid;
+				if (fileHeader.version == 'L') // Version 1
+				{
+					uint32_t itemCount = 0;
+
+					// Spheres
+					rw.read((char*)&itemCount, sizeof(itemCount));
+					if (rw.gcount() != sizeof(itemCount)) return false;
+
+					if (itemCount)
+					{
+						CollisionModels[i].SphereCount = itemCount;
+						CollisionModels[i].SphereData = new structSphereData[CollisionModels[i].SphereCount];
+
+						for (int j = 0; j < itemCount; ++j)
+						{
+							rw.read((char*) &(CollisionModels[i].SphereData[j].Radius), sizeof(float));
+							rw.read((char*) &(CollisionModels[i].SphereData[j].Offset), sizeof(Vector));
+							rw.seekg(4, std::ios::cur); // Skip surface data
+						}
+					}
+					else CollisionModels[i].SphereData = NULL;
+
+					rw.seekg(4, std::ios::cur); // Skip unknown data
+
+					// Boxes
+					rw.read((char*)&itemCount, sizeof(itemCount));
+					if (rw.gcount() != sizeof(itemCount)) return false;
+
+					if (itemCount)
+					{
+						CollisionModels[i].BoxCount = itemCount;
+						CollisionModels[i].BoxData = new structBoxData[CollisionModels[i].BoxCount];
+						ColBox *boxTemp = new ColBox[CollisionModels[i].BoxCount];
+
+						for (int j = 0; j < itemCount; ++j)
+						{
+							rw.read((char*)&boxTemp[j], sizeof(ColBox));
+
+							CollisionModels[i].BoxData[j].Center.x = (boxTemp[j].box_min.x + boxTemp[j].box_max.x) / 2.0f;
+							CollisionModels[i].BoxData[j].Center.y = (boxTemp[j].box_min.y + boxTemp[j].box_max.y) / 2.0f;
+							CollisionModels[i].BoxData[j].Center.z = (boxTemp[j].box_min.z + boxTemp[j].box_max.z) / 2.0f;
+
+							CollisionModels[i].BoxData[j].Size.x = (boxTemp[j].box_max.x - boxTemp[j].box_min.x) / 2.0f;
+							CollisionModels[i].BoxData[j].Size.y = (boxTemp[j].box_max.y - boxTemp[j].box_min.y) / 2.0f;
+							CollisionModels[i].BoxData[j].Size.z = (boxTemp[j].box_max.z - boxTemp[j].box_min.z) / 2.0f;
+
+							rw.seekg(4, std::ios::cur);
+						}
+					}
+					else CollisionModels[i].BoxData = NULL;
+
+					// Vertices
+					rw.read((char*)&itemCount, sizeof(itemCount));
+					if (rw.gcount() != sizeof(itemCount)) return false;
+
+					if (itemCount)
+					{
+						Vector *vertices = new Vector[itemCount];
+						rw.read((char*)vertices, sizeof(Vector) * itemCount);
+
+						// Faces
+						rw.read((char*)&itemCount, sizeof(itemCount));
+						if (rw.gcount() != sizeof(itemCount))
+						{
+							delete[] vertices;
+							return false;
+						}
+
+						if (itemCount)
+						{
+							CollisionModels[i].FaceCount = itemCount;
+							CollisionModels[i].FacesData = new structFacesData[CollisionModels[i].FaceCount];
+
+
+							for (int j = 0; j < itemCount; ++j)
+							{
+								uint32_t indexes[3];
+								rw.read((char*)&indexes, sizeof(indexes));
+								rw.seekg(4, std::ios::cur); // Skip surface data
+
+								CollisionModels[i].FacesData[j].FaceA = vertices[indexes[0]];
+								CollisionModels[i].FacesData[j].FaceB = vertices[indexes[1]];
+								CollisionModels[i].FacesData[j].FaceC = vertices[indexes[2]];
+							}
+						}
+						else
+						{
+							delete[] vertices;
+							CollisionModels[i].FacesData = NULL;
+						}
+					}
+					else CollisionModels[i].FacesData = NULL;
+
+					// Prepare for reading the next collision
+					rw.seekg(beginPos + 8 + fileHeader.size);
+
+					ModelRef[CollisionModels[i].Modelid] = i;
+					ColAndreasColObject* colObject = new ColAndreasColObject(i, false);
+					ColAndreasColObject* convex = new ColAndreasColObject(i, true);
+					colObjects.push_back(colObject);
+					colConvex.push_back(convex->getCompoundShape());
+					return true;
+				}
+				else
+				{
+					ColItems fileItems;
+					rw.read((char*)&fileItems, sizeof(fileItems));
+
+					if (rw.gcount() == sizeof(fileItems))
+					{
+						CollisionModels[i].BoxCount = fileItems.numBoxes;
+						CollisionModels[i].SphereCount = fileItems.numSpheres;
+						CollisionModels[i].FaceCount = fileItems.numFaces;
+
+						// Box Data
+						if (fileItems.numBoxes)
+						{
+							CollisionModels[i].BoxData = new structBoxData[fileItems.numBoxes];
+							ColBox *boxTemp = new ColBox[fileItems.numBoxes];
+							rw.seekg(beginPos + 4 + fileItems.offBoxes);
+
+							for (int j = 0; j < fileItems.numBoxes; ++j)
+							{
+								rw.read((char*)&boxTemp[j], sizeof(ColBox));
+
+								CollisionModels[i].BoxData[j].Center.x = (boxTemp[j].box_min.x + boxTemp[j].box_max.x) / 2.0f;
+								CollisionModels[i].BoxData[j].Center.y = (boxTemp[j].box_min.y + boxTemp[j].box_max.y) / 2.0f;
+								CollisionModels[i].BoxData[j].Center.z = (boxTemp[j].box_min.z + boxTemp[j].box_max.z) / 2.0f;
+
+								CollisionModels[i].BoxData[j].Size.x = (boxTemp[j].box_max.x - boxTemp[j].box_min.x) / 2.0f;
+								CollisionModels[i].BoxData[j].Size.y = (boxTemp[j].box_max.y - boxTemp[j].box_min.y) / 2.0f;
+								CollisionModels[i].BoxData[j].Size.z = (boxTemp[j].box_max.z - boxTemp[j].box_min.z) / 2.0f;
+
+								rw.seekg(4, std::ios::cur); // Skip surface data
+							}
+						}
+						else CollisionModels[i].BoxData = NULL;
+
+						if (fileItems.numSpheres)
+						{
+							CollisionModels[i].SphereData = new structSphereData[fileItems.numSpheres];
+							rw.seekg(beginPos + 4 + fileItems.offSpheres);
+
+							for (int j = 0; j < fileItems.numSpheres; ++j)
+							{
+								rw.read((char*)&CollisionModels[i].SphereData[j], sizeof(structSphereData));
+								rw.seekg(4, std::ios::cur); // Skip surface data
+							}
+						}
+						else CollisionModels[i].SphereData = NULL;
+
+						if (fileItems.numFaces)
+						{
+							uint16_t topIndex = 0;
+							uint16_t(*faceIndexes)[3] = new uint16_t[fileItems.numFaces][3];
+
+							CollisionModels[i].FacesData = new structFacesData[CollisionModels[i].FaceCount];
+							rw.seekg(beginPos + 4 + fileItems.offFaces);
+
+							for (int j = 0; j < fileItems.numFaces; ++j)
+							{
+								rw.read((char*)(faceIndexes + j), sizeof(uint16_t) * 3);
+								rw.seekg(2, std::ios::cur); // Skip surface data
+
+								if (faceIndexes[j][0] > topIndex) topIndex = faceIndexes[j][0];
+								if (faceIndexes[j][1] > topIndex) topIndex = faceIndexes[j][1];
+								if (faceIndexes[j][2] > topIndex) topIndex = faceIndexes[j][2];
+							}
+
+							Vector *vertices = new Vector[topIndex + 1];
+							rw.seekg(beginPos + 4 + fileItems.offVertices);
+
+							for (int j = 0; j < topIndex + 1; ++j)
+							{
+								int16_t vertexData[3];
+								rw.read((char*)&vertexData, sizeof(vertexData));
+
+								vertices[j].x = float(vertexData[0]) / 128.0f;
+								vertices[j].y = float(vertexData[1]) / 128.0f;
+								vertices[j].z = float(vertexData[2]) / 128.0f;
+							}
+
+							for (int j = 0; j < fileItems.numFaces; ++j)
+							{
+
+								CollisionModels[i].FacesData[j].FaceA = (vertices[faceIndexes[j][0]]);
+								CollisionModels[i].FacesData[j].FaceB = (vertices[faceIndexes[j][1]]);
+								CollisionModels[i].FacesData[j].FaceC = (vertices[faceIndexes[j][2]]);
+							}
+
+							delete[] faceIndexes;
+						}
+						else CollisionModels[i].FacesData = NULL;
+
+						// Prepare for reading the next collision
+						rw.seekg(beginPos + 8 + fileHeader.size);
+
+						ModelRef[CollisionModels[i].CustomModelid] = i;
+
+						ColAndreasColObject* colObject = new ColAndreasColObject(i, false);
+						ColAndreasColObject* convex = new ColAndreasColObject(i, true);
+						colObjects.push_back(colObject);
+						colConvex.push_back(convex->getCompoundShape());
+						return true;
+					}
+				}
+			}
+		}
+		return false;
+	}
+}

--- a/src/renderware.cpp
+++ b/src/renderware.cpp
@@ -1,0 +1,200 @@
+#include <cstdlib>
+#include "ColAndreasDatabaseReader.h"
+#include <renderware.h>
+using namespace std;
+
+namespace rw 
+{
+	bool HeaderInfo::read(istream &rw)
+	{
+		uint32 buf[3];
+		rw.read((char*)buf, 12);
+		if (rw.eof())
+			return false;
+		type = buf[0];
+		length = buf[1];
+		build = buf[2];
+		if (build & 0xFFFF0000)
+			version = ((build >> 14) & 0x3FF00) |
+			((build >> 16) & 0x3F) |
+			0x30000;
+		else
+			version = build << 8;
+		return true;
+	}
+
+	bool HeaderInfo::peek(istream &rw)
+	{
+		if (!read(rw))
+			return false;
+		rw.seekg(-12, ios::cur);
+		return true;
+	}
+
+	uint32 HeaderInfo::write(ostream &rw)
+	{
+		uint32 buf[3];
+		buf[0] = type;
+		buf[1] = length;
+		buf[2] = build;
+		rw.write((char*)buf, 12);
+		return 3 * sizeof(uint32);
+	}
+
+	bool HeaderInfo::findChunk(istream &rw, uint32 type)
+	{
+		while (read(rw)) {
+			if (this->type == CHUNK_NAOBJECT)
+				return false;
+			if (this->type == type)
+				return true;
+			rw.seekg(length, ios::cur);
+		}
+		return false;
+	}
+
+	void ChunkNotFound(CHUNK_TYPE chunk, uint32 address)
+	{
+		cerr << "chunk " << hex << chunk << " not found at 0x";
+		cerr << hex << address << endl;
+		exit(1);
+	}
+
+	int8 readInt8(istream &rw)
+	{
+		int8 tmp;
+		rw.read(reinterpret_cast <char *> (&tmp), sizeof(int8));
+		return tmp;
+	}
+
+	uint8 readUInt8(istream &rw)
+	{
+		uint8 tmp;
+		rw.read(reinterpret_cast <char *> (&tmp), sizeof(uint8));
+		return tmp;
+	}
+
+	int16 readInt16(istream &rw)
+	{
+		int16 tmp;
+		rw.read(reinterpret_cast <char *> (&tmp), sizeof(int16));
+		return tmp;
+	}
+
+	uint16 readUInt16(istream &rw)
+	{
+		uint16 tmp;
+		rw.read(reinterpret_cast <char *> (&tmp), sizeof(uint16));
+		return tmp;
+	}
+
+	int32 readInt32(istream &rw)
+	{
+		int32 tmp;
+		rw.read(reinterpret_cast <char *> (&tmp), sizeof(int32));
+		return tmp;
+	}
+
+	uint32 readUInt32(istream &rw)
+	{
+		uint32 tmp;
+		rw.read(reinterpret_cast <char *> (&tmp), sizeof(uint32));
+		return tmp;
+	}
+
+	float32 readFloat32(istream &rw)
+	{
+		float32 tmp;
+		rw.read(reinterpret_cast <char *> (&tmp), sizeof(float32));
+		return tmp;
+	}
+
+	const char *chunks[] = { "None", "Struct", "String", "Extension", "Unknown",
+		"Camera", "Texture", "Material", "Material List", "Atomic Section",
+		"Plane Section", "World", "Spline", "Matrix", "Frame List",
+		"Geometry", "Clump", "Unknown", "Light", "Unicode String", "Atomic",
+		"Texture Native", "Texture Dictionary", "Animation Database",
+		"Image", "Skin Animation", "Geometry List", "Anim Animation",
+		"Team", "Crowd", "Delta Morph Animation", "Right To Render",
+		"MultiTexture Effect Native", "MultiTexture Effect Dictionary",
+		"Team Dictionary", "Platform Independet Texture Dictionary",
+		"Table of Contents", "Particle Standard Global Data", "AltPipe",
+		"Platform Independet Peds", "Patch Mesh", "Chunk Group Start",
+		"Chunk Group End", "UV Animation Dictionary", "Coll Tree"
+	};
+
+	/* From 0x0101 through 0x0135 */
+	const char *toolkitchunks0[] = { "Metrics PLG", "Spline PLG", "Stereo PLG",
+		"VRML PLG", "Morph PLG", "PVS PLG", "Memory Leak PLG", "Animation PLG",
+		"Gloss PLG", "Logo PLG", "Memory Info PLG", "Random PLG",
+		"PNG Image PLG", "Bone PLG", "VRML Anim PLG", "Sky Mipmap Val",
+		"MRM PLG", "LOD Atomic PLG", "ME PLG", "Lightmap PLG",
+		"Refine PLG", "Skin PLG", "Label PLG", "Particles PLG", "GeomTX PLG",
+		"Synth Core PLG", "STQPP PLG",
+		"Part PP PLG", "Collision PLG", "HAnim PLG", "User Data PLG",
+		"Material Effects PLG", "Particle System PLG", "Delta Morph PLG",
+		"Patch PLG", "Team PLG", "Crowd PP PLG", "Mip Split PLG",
+		"Anisotrophy PLG", "Not used", "GCN Material PLG", "Geometric PVS PLG",
+		"XBOX Material PLG", "Multi Texture PLG", "Chain PLG", "Toon PLG",
+		"PTank PLG", "Particle Standard PLG", "PDS PLG", "PrtAdv PLG",
+		"Normal Map PLG", "ADC PLG", "UV Animation PLG"
+	};
+
+	/* From 0x0180 through 0x01c1 */
+	const char *toolkitchunks1[] = {
+		"Character Set PLG", "NOHS World PLG", "Import Util PLG",
+		"Slerp PLG", "Optim PLG", "TL World PLG", "Database PLG",
+		"Raytrace PLG", "Ray PLG", "Library PLG",
+		"Not used", "Not used", "Not used", "Not used", "Not used", "Not used",
+		"2D PLG", "Tile Render PLG", "JPEG Image PLG", "TGA Image PLG",
+		"GIF Image PLG", "Quat PLG", "Spline PVS PLG", "Mipmap PLG",
+		"MipmapK PLG", "2D Font", "Intersection PLG", "TIFF Image PLG",
+		"Pick PLG", "BMP Image PLG", "RAS Image PLG", "Skin FX PLG",
+		"VCAT PLG", "2D Path", "2D Brush", "2D Object", "2D Shape", "2D Scene",
+		"2D Pick Region", "2D Object String", "2D Animation PLG",
+		"2D Animation",
+		"Not used", "Not used", "Not used", "Not used", "Not used", "Not used",
+		"2D Keyframe", "2D Maestro", "Barycentric",
+		"Platform Independent Texture Dictionary TK", "TOC TK", "TPL TK",
+		"AltPipe TK", "Animation TK", "Skin Split Tookit", "Compressed Key TK",
+		"Geometry Conditioning PLG", "Wing PLG", "Generic Pipeline TK",
+		"Lightmap Conversion TK", "Filesystem PLG", "Dictionary TK",
+		"UV Animation Linear", "UV Animation Parameter"
+	};
+
+	const char *RSchunks[] = { "Unused 1", "Unused 2", "Unused 3",
+		"Pipeline Set", "Unused 5", "Unused 6", "Specular Material",
+		"Unused 8", "2dfx", "Night Vertex Colors", "Collision Model",
+		"Unused 12", "Reflection Material", "Mesh Extension", "Frame",
+		"Unused 16"
+	};
+
+	string getChunkName(uint32 i)
+	{
+		switch (i) {
+		case 0x50E:
+			return "Bin Mesh PLG";
+			break;
+		case 0x510:
+			return "Native Data PLG";
+			break;
+		case 0xF21E:
+			return "ZModeler Lock";
+			break;
+		default:
+			break;
+		}
+
+		if (i <= 45)
+			return chunks[i];
+		else if (i <= 0x0253F2FF && i >= 0x0253F2F0)
+			return RSchunks[i - 0x0253F2F0];
+		else if (i <= 0x0135 && i >= 0x0101)
+			return toolkitchunks0[i - 0x0101];
+		else if (i <= 0x01C0 && i >= 0x0181)
+			return toolkitchunks1[i - 0x0181];
+		else
+			return "Unknown";
+	}
+
+}

--- a/src/renderware.h
+++ b/src/renderware.h
@@ -1,0 +1,189 @@
+#ifndef _RENDERWARE_H_
+#define _RENDERWARE_H_
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#include <iostream>
+#include <vector>
+#include <string>
+
+#ifdef DEBUG
+#define READ_HEADER(x)\
+	header.read(rw);\
+	if (header.type != (x)) {\
+		cerr << filename << " ";\
+		ChunkNotFound((x), rw.tellg());\
+	}
+#else
+#define READ_HEADER(x)\
+	header.read(rw);
+#endif
+
+namespace rw {
+
+	typedef char int8;
+	typedef short int16;
+	typedef int int32;
+	typedef long long int64;
+	typedef unsigned char uint8;
+	typedef unsigned short uint16;
+	typedef unsigned int uint32;
+	typedef unsigned long long uint64;
+	typedef float float32;
+
+	extern char *filename;
+	extern uint32 version;
+
+	enum CHUNK_TYPE {
+		CHUNK_NAOBJECT = 0x0,
+		CHUNK_STRUCT = 0x1,
+		CHUNK_STRING = 0x2,
+		CHUNK_EXTENSION = 0x3,
+		CHUNK_CAMERA = 0x5,
+		CHUNK_TEXTURE = 0x6,
+		CHUNK_MATERIAL = 0x7,
+		CHUNK_MATLIST = 0x8,
+		CHUNK_ATOMICSECT = 0x9,
+		CHUNK_PLANESECT = 0xA,
+		CHUNK_WORLD = 0xB,
+		CHUNK_SPLINE = 0xC,
+		CHUNK_MATRIX = 0xD,
+		CHUNK_FRAMELIST = 0xE,
+		CHUNK_GEOMETRY = 0xF,
+		CHUNK_CLUMP = 0x10,
+		CHUNK_LIGHT = 0x12,
+		CHUNK_UNICODESTRING = 0x13,
+		CHUNK_ATOMIC = 0x14,
+		CHUNK_TEXTURENATIVE = 0x15,
+		CHUNK_TEXDICTIONARY = 0x16,
+		CHUNK_ANIMDATABASE = 0x17,
+		CHUNK_IMAGE = 0x18,
+		CHUNK_SKINANIMATION = 0x19,
+		CHUNK_GEOMETRYLIST = 0x1A,
+		CHUNK_ANIMANIMATION = 0x1B,
+		CHUNK_HANIMANIMATION = 0x1B,
+		CHUNK_TEAM = 0x1C,
+		CHUNK_CROWD = 0x1D,
+		CHUNK_RIGHTTORENDER = 0x1F,
+		CHUNK_MTEFFECTNATIVE = 0x20,
+		CHUNK_MTEFFECTDICT = 0x21,
+		CHUNK_TEAMDICTIONARY = 0x22,
+		CHUNK_PITEXDICTIONARY = 0x23,
+		CHUNK_TOC = 0x24,
+		CHUNK_PRTSTDGLOBALDATA = 0x25,
+		CHUNK_ALTPIPE = 0x26,
+		CHUNK_PIPEDS = 0x27,
+		CHUNK_PATCHMESH = 0x28,
+		CHUNK_CHUNKGROUPSTART = 0x29,
+		CHUNK_CHUNKGROUPEND = 0x2A,
+		CHUNK_UVANIMDICT = 0x2B,
+		CHUNK_COLLTREE = 0x2C,
+		CHUNK_ENVIRONMENT = 0x2D,
+		CHUNK_COREPLUGINIDMAX = 0x2E,
+
+		CHUNK_MORPH = 0x105,
+		CHUNK_SKYMIPMAP = 0x110,
+		CHUNK_SKIN = 0x116,
+		CHUNK_PARTICLES = 0x118,
+		CHUNK_HANIM = 0x11E,
+		CHUNK_MATERIALEFFECTS = 0x120,
+		CHUNK_PDSPLG = 0x131,
+		CHUNK_ADCPLG = 0x134,
+		CHUNK_UVANIMPLG = 0x135,
+		CHUNK_BINMESH = 0x50E,
+		CHUNK_NATIVEDATA = 0x510,
+		CHUNK_VERTEXFORMAT = 0x510,
+
+		CHUNK_PIPELINESET = 0x253F2F3,
+		CHUNK_SPECULARMAT = 0x253F2F6,
+		CHUNK_2DFX = 0x253F2F8,
+		CHUNK_NIGHTVERTEXCOLOR = 0x253F2F9,
+		CHUNK_COLLISIONMODEL = 0x253F2FA,
+		CHUNK_REFLECTIONMAT = 0x253F2FC,
+		CHUNK_MESHEXTENSION = 0x253F2FD,
+		CHUNK_FRAME = 0x253F2FE,
+		CHUNK_SAMPCOLLISION = 0x253F2FF
+	};
+	typedef enum CHUNK_TYPE CHUNK_TYPE;
+
+	struct HeaderInfo
+	{
+		uint32 type;
+		uint32 length;
+		uint32 build;
+		uint32 version;
+		bool read(std::istream &rw);
+		bool peek(std::istream &rw);
+		uint32 write(std::ostream &rw);
+		bool findChunk(std::istream &rw, uint32 type);
+	};
+
+	void ChunkNotFound(CHUNK_TYPE chunk, uint32 address);
+	int8 readInt8(std::istream &rw);
+	uint8 readUInt8(std::istream &rw);
+	int16 readInt16(std::istream &rw);
+	uint16 readUInt16(std::istream &rw);
+	int32 readInt32(std::istream &rw);
+	uint32 readUInt32(std::istream &rw);
+	float32 readFloat32(std::istream &rw);
+
+	std::string getChunkName(uint32 i);
+
+	struct ColHeader
+	{
+		char validator[3];
+		char version;
+		unsigned int size;
+		char modelName[22];
+		short modelid;
+	};
+
+	struct ColBox
+	{
+		Vector box_min;
+		Vector box_max;
+	};
+
+	struct ColItems
+	{
+		uint16_t numSpheres;
+		uint16_t numBoxes;
+		uint16_t numFaces;
+		uint8_t numWheels;
+		uint8_t padding;
+		uint32_t flags;
+		uint32_t offSpheres;
+		uint32_t offBoxes;
+		uint32_t offSuspensionLines;
+		uint32_t offVertices;
+		uint32_t offFaces;
+		uint32_t offTrianglePlanes;
+
+		uint32_t numShadow;
+		uint32_t offShadowVert;
+		uint32_t offShadowFaces;
+	};
+
+	struct Collision
+	{
+		bool read(std::istream &dff, int32_t modelid);
+	};
+
+	struct Clump
+	{
+		int32_t iModelId = 0;
+		Collision collision;
+
+		/* Extensions */
+		/* collision file */
+		bool hasCollision;
+
+		/* functions */
+		bool read(std::istream &dff, int32_t modelid);
+		bool readExtension(std::istream &dff);
+	};
+
+}
+
+#endif


### PR DESCRIPTION
Short explanation:
What it does is loading collision data from given dff file by using function `CA_LoadFromDff` and add those data to ColAndreas pools. All tests were successful but there's still a chance that things break.

I am also not sure if I should hook AddSimpleModel or create an alternative like `*_DC` functions.
So I just leave it like and scripters can decide what they want and do it by themselves.

Thanks to 
[J0shES](https://github.com/Alasnkz) for some advices
[TommyB](https://gist.github.com/TommyB123) for beta testing