### PR TITLE
fix: update pawn.json for new release structure

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -4,15 +4,15 @@
     "include_path": "Server/include",
     "resources": [
         {
-            "name": "^ColAndreas_static.so$",
+            "name": "^ColAndreas_ubuntu.zip$",
             "platform": "linux",
-            "archive": false,
-            "plugins": ["colandreas_static.so"]
+            "archive": true,
+            "plugins": ["ColAndreas.so"]
         },
         {
-            "name": "^ColAndreas.dll$",
+            "name": "^ColAndreas_win32.zip$",
             "platform": "windows",
-            "archive": false,
+            "archive": true,
             "plugins": ["ColAndreas.dll"]
         }
     ],


### PR DESCRIPTION
Because the latest release changed from bare files to archived files, this fixes that.

However, the problem with this is users will not be able to use an older version. It would be best if you just stick to the existing distribution method. Compression isn't really a requirement as the files as so small and there are no additional files supplied with the plugin anyway.