### PR TITLE
Add CA_RestoreBuilding

### DIFF
--- a/Server/include/colandreas.inc
+++ b/Server/include/colandreas.inc
@@ -77,6 +77,23 @@ native CA_RemoveBuilding(modelid, Float:x, Float:y, Float:z, Float:radius);
 
 /**--------------------------------------------------------------------------**\
 <summary>
+	CA_RestoreBuilding
+</summary>
+<param name="modelid">The removed model to be restored</param>
+<param name="Float:x, Float:y, Float:z">The coordinates in which the objects will be restored</param>
+<param name="Float:radius">The radius around the specified point to restore from</param>
+<returns>
+	0 when the map is not initialized
+	1 when successfully restored
+</returns>
+<remarks>
+    You must use this function after using `CA_Init`
+</remarks>
+\**--------------------------------------------------------------------------**/
+native CA_RestoreBuilding(modelid, Float:x, Float:y, Float:z, Float:radius);
+
+/**--------------------------------------------------------------------------**\
+<summary>
 	CA_RayCastLine
 </summary>
 <param name="Float:StartX, Float:StartY, Float:StartZ">The beginning point of the ray</param>

--- a/src/ColAndreas.cpp
+++ b/src/ColAndreas.cpp
@@ -87,6 +87,7 @@ AMX_NATIVE_INFO PluginNatives[] =
 	{ "CA_EulerToQuat", ColAndreasNatives::CA_EulerToQuat },
 	{ "CA_QuatToEuler", ColAndreasNatives::CA_QuatToEuler },
 	{ "CA_RemoveBuilding", ColAndreasNatives::CA_RemoveBuilding },
+	{ "CA_RestoreBuilding", ColAndreasNatives::CA_RestoreBuilding },
 	{ "CA_SetObjectPos", ColAndreasNatives::CA_SetObjectPos },
 	{ "CA_SetObjectRot", ColAndreasNatives::CA_SetObjectRot },
 	{ "CA_GetModelBoundingSphere", ColAndreasNatives::CA_GetModelBoundingSphere },

--- a/src/ColAndreasDatabaseReader.cpp
+++ b/src/ColAndreasDatabaseReader.cpp
@@ -3,7 +3,7 @@
 
 std::map<uint16_t, CollisionModelstructure> CollisionModels;
 ItemPlacementstructure* ModelPlacements;
-
+std::vector<ItemPlacementstructure*> RemovedGameObjects;
 uint16_t ModelCount = 0;
 uint32_t IPLCount = 0;
 std::map<int32_t, uint16_t> ModelRef;

--- a/src/ColAndreasDatabaseReader.h
+++ b/src/ColAndreasDatabaseReader.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <fstream>
 #include <cstring>
+#include <vector>
 #include <map>
 
 using namespace std;
@@ -112,6 +113,7 @@ returns a boolean true if function suceeded, otherwise false.
 bool ReadColandreasDatabaseFile(std::string FileLocation);
 extern std::map<uint16_t, CollisionModelstructure> CollisionModels;
 extern ItemPlacementstructure* ModelPlacements;
+extern std::vector<ItemPlacementstructure*> RemovedGameObjects;
 extern uint16_t ModelCount;
 extern uint32_t IPLCount;
 extern std::map<int32_t, uint16_t> ModelRef;

--- a/src/ColObject.cpp
+++ b/src/ColObject.cpp
@@ -324,7 +324,7 @@ RemovedBuildingManager::RemovedBuildingManager()
 {
 }
 
-bool RemovedBuildingManager::isRemoved(uint16_t model, Vector position)
+bool RemovedBuildingManager::isRemoved(int16_t model, Vector position)
 {
 	for (uint16_t i = 0; i < removedBuildings.size(); i++)
 	{

--- a/src/ColObject.cpp
+++ b/src/ColObject.cpp
@@ -1,5 +1,6 @@
 #include "ColObject.h"
 #include "WaterArray.h"
+#include "DynamicWorld.h"
 #include "ColAndreasDatabaseReader.h"
 
 // SAMP objects only go up 19999
@@ -341,6 +342,30 @@ bool RemovedBuildingManager::isRemoved(uint16_t model, Vector position)
 	return 0;
 }
 
+void RemovedBuildingManager::restoreBuilding(removeBuildingData targetData)
+{
+	for (uint16_t i = 0; i < RemovedGameObjects.size(); i++)
+	{
+		if ((targetData.r_Model == RemovedGameObjects[i]->Modelid || targetData.r_Model == -1) && RemovedGameObjects[i] != nullptr)
+		{
+			btScalar dist = btDistance(btVector3(btScalar(targetData.r_X), btScalar(targetData.r_Y), btScalar(targetData.r_Z)),
+				btVector3(btScalar(RemovedGameObjects[i]->Position.x), btScalar(RemovedGameObjects[i]->Position.y), btScalar(RemovedGameObjects[i]->Position.z)));
+
+			if (dist <= btScalar(targetData.r_Radius))
+			{
+				uint16_t index = ModelRef[RemovedGameObjects[i]->Modelid];
+				if(index == 65535) continue;
+
+				collisionWorld->createColAndreasMapObject(0, RemovedGameObjects[i]->Modelid,
+					btQuaternion(RemovedGameObjects[i]->Rotation.x, RemovedGameObjects[i]->Rotation.y, RemovedGameObjects[i]->Rotation.z, RemovedGameObjects[i]->Rotation.w),
+					btVector3(RemovedGameObjects[i]->Position.x, RemovedGameObjects[i]->Position.y, RemovedGameObjects[i]->Position.z));
+
+				RemovedGameObjects[i] = nullptr;
+			}
+		}
+	}
+}
+
 void RemovedBuildingManager::addBuilding(removeBuildingData removeData)
 {
 	removedBuildings.push_back(removeData);
@@ -371,6 +396,9 @@ void InitCollisionMap(btDynamicsWorld* collisionWorld, RemovedBuildingManager* r
 			ColAndreasMapObject* tmpObject;
 			tmpObject = new ColAndreasMapObject(ModelPlacements[i].Modelid, btQuaternion(ModelPlacements[i].Rotation.x, ModelPlacements[i].Rotation.y, ModelPlacements[i].Rotation.z, ModelPlacements[i].Rotation.w), btVector3(ModelPlacements[i].Position.x, ModelPlacements[i].Position.y, ModelPlacements[i].Position.z), collisionWorld);
 
+		}
+		else {
+			RemovedGameObjects.push_back(new ItemPlacementstructure(ModelPlacements[i]));
 		}
 	}
 }

--- a/src/ColObject.cpp
+++ b/src/ColObject.cpp
@@ -346,21 +346,24 @@ void RemovedBuildingManager::restoreBuilding(removeBuildingData targetData)
 {
 	for (uint16_t i = 0; i < RemovedGameObjects.size(); i++)
 	{
-		if ((targetData.r_Model == RemovedGameObjects[i]->Modelid || targetData.r_Model == -1) && RemovedGameObjects[i] != nullptr)
+		if (RemovedGameObjects[i] != nullptr)
 		{
-			btScalar dist = btDistance(btVector3(btScalar(targetData.r_X), btScalar(targetData.r_Y), btScalar(targetData.r_Z)),
-				btVector3(btScalar(RemovedGameObjects[i]->Position.x), btScalar(RemovedGameObjects[i]->Position.y), btScalar(RemovedGameObjects[i]->Position.z)));
-
-			if (dist <= btScalar(targetData.r_Radius))
+			if ((targetData.r_Model == RemovedGameObjects[i]->Modelid || targetData.r_Model == -1))
 			{
-				uint16_t index = ModelRef[RemovedGameObjects[i]->Modelid];
-				if(index == 65535) continue;
+				btScalar dist = btDistance(btVector3(btScalar(targetData.r_X), btScalar(targetData.r_Y), btScalar(targetData.r_Z)),
+					btVector3(btScalar(RemovedGameObjects[i]->Position.x), btScalar(RemovedGameObjects[i]->Position.y), btScalar(RemovedGameObjects[i]->Position.z)));
 
-				collisionWorld->createColAndreasMapObject(0, RemovedGameObjects[i]->Modelid,
-					btQuaternion(RemovedGameObjects[i]->Rotation.x, RemovedGameObjects[i]->Rotation.y, RemovedGameObjects[i]->Rotation.z, RemovedGameObjects[i]->Rotation.w),
-					btVector3(RemovedGameObjects[i]->Position.x, RemovedGameObjects[i]->Position.y, RemovedGameObjects[i]->Position.z));
+				if (dist <= btScalar(targetData.r_Radius))
+				{
+					uint16_t index = ModelRef[RemovedGameObjects[i]->Modelid];
+					if (index == 65535) continue;
 
-				RemovedGameObjects[i] = nullptr;
+					collisionWorld->createColAndreasMapObject(0, RemovedGameObjects[i]->Modelid,
+						btQuaternion(RemovedGameObjects[i]->Rotation.x, RemovedGameObjects[i]->Rotation.y, RemovedGameObjects[i]->Rotation.z, RemovedGameObjects[i]->Rotation.w),
+						btVector3(RemovedGameObjects[i]->Position.x, RemovedGameObjects[i]->Position.y, RemovedGameObjects[i]->Position.z));
+
+					RemovedGameObjects[i] = nullptr;
+				}
 			}
 		}
 	}

--- a/src/ColObject.h
+++ b/src/ColObject.h
@@ -10,7 +10,7 @@
 
 struct removeBuildingData
 {
-	uint16_t r_Model;
+	int16_t r_Model;
 	float r_X;
 	float r_Y;
 	float r_Z;
@@ -110,7 +110,7 @@ class RemovedBuildingManager
 {
 public:
 	RemovedBuildingManager();
-	bool isRemoved(uint16_t model, Vector position);
+	bool isRemoved(int16_t model, Vector position);
 	void addBuilding(removeBuildingData removeData);
 	void restoreBuilding(removeBuildingData targetData);
 private:

--- a/src/ColObject.h
+++ b/src/ColObject.h
@@ -112,6 +112,7 @@ public:
 	RemovedBuildingManager();
 	bool isRemoved(uint16_t model, Vector position);
 	void addBuilding(removeBuildingData removeData);
+	void restoreBuilding(removeBuildingData targetData);
 private:
 	std::vector <removeBuildingData> removedBuildings;
 };

--- a/src/Natives.cpp
+++ b/src/Natives.cpp
@@ -437,6 +437,20 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_RemoveBuilding(AMX *amx, cell *params
 	return 0;
 }
 
+cell AMX_NATIVE_CALL ColAndreasNatives::CA_RestoreBuilding(AMX *amx, cell *params)
+{
+
+	removeBuildingData tmp;
+	tmp.r_Model = static_cast<uint16_t>(params[1]);
+
+	tmp.r_X = amx_ctof(params[2]);
+	tmp.r_Y = amx_ctof(params[3]);
+	tmp.r_Z = amx_ctof(params[4]);
+	tmp.r_Radius = amx_ctof(params[5]);
+	collisionWorld->removedManager->restoreBuilding(tmp);
+	return 1;
+}
+
 cell AMX_NATIVE_CALL ColAndreasNatives::CA_SetObjectPos(AMX *amx, cell *params)
 {
 	uint16_t index = static_cast<uint16_t>(params[1]);

--- a/src/Natives.cpp
+++ b/src/Natives.cpp
@@ -439,16 +439,23 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_RemoveBuilding(AMX *amx, cell *params
 
 cell AMX_NATIVE_CALL ColAndreasNatives::CA_RestoreBuilding(AMX *amx, cell *params)
 {
+	if (colInit)
+	{
+		removeBuildingData tmp;
+		tmp.r_Model = static_cast<int16_t>(params[1]);
 
-	removeBuildingData tmp;
-	tmp.r_Model = static_cast<uint16_t>(params[1]);
-
-	tmp.r_X = amx_ctof(params[2]);
-	tmp.r_Y = amx_ctof(params[3]);
-	tmp.r_Z = amx_ctof(params[4]);
-	tmp.r_Radius = amx_ctof(params[5]);
-	collisionWorld->removedManager->restoreBuilding(tmp);
-	return 1;
+		tmp.r_X = amx_ctof(params[2]);
+		tmp.r_Y = amx_ctof(params[3]);
+		tmp.r_Z = amx_ctof(params[4]);
+		tmp.r_Radius = amx_ctof(params[5]);
+		collisionWorld->removedManager->restoreBuilding(tmp);
+		return 1;
+	}
+	else
+	{
+		logprintf("ERROR: CA_RestoreBuilding : Map is not initialized yet. Use this after CA_Init.");
+	}
+	return 0;
 }
 
 cell AMX_NATIVE_CALL ColAndreasNatives::CA_SetObjectPos(AMX *amx, cell *params)

--- a/src/Natives.cpp
+++ b/src/Natives.cpp
@@ -421,7 +421,7 @@ cell AMX_NATIVE_CALL ColAndreasNatives::CA_RemoveBuilding(AMX *amx, cell *params
 	if (!colInit)
 	{
 		removeBuildingData tmp;
-		tmp.r_Model = static_cast<uint16_t>(params[1]);
+		tmp.r_Model = static_cast<int16_t>(params[1]);
 
 		tmp.r_X = amx_ctof(params[2]);
 		tmp.r_Y = amx_ctof(params[3]);

--- a/src/Natives.h
+++ b/src/Natives.h
@@ -21,6 +21,7 @@ public:
 	static cell AMX_NATIVE_CALL CA_EulerToQuat(AMX *amx, cell *params);
 	static cell AMX_NATIVE_CALL CA_QuatToEuler(AMX *amx, cell *params);
 	static cell AMX_NATIVE_CALL CA_RemoveBuilding(AMX *amx, cell *params);
+	static cell AMX_NATIVE_CALL CA_RestoreBuilding(AMX *amx, cell *params);
 	static cell AMX_NATIVE_CALL CA_SetObjectPos(AMX *amx, cell *params);
 	static cell AMX_NATIVE_CALL CA_SetObjectRot(AMX *amx, cell *params);
 	static cell AMX_NATIVE_CALL CA_GetModelBoundingSphere(AMX *amx, cell *params);


### PR DESCRIPTION
This PR adds a new native, named CA_RestoreBuilding, to restore collisions of gtasa default objects that are removed with CA_RemoveBuilding.
This also needs to be used after CA_Init().

PS: This PR also fixes inability of using `-1` in CA_RemoveBuilding cause data type of passed modelid was set to uint16 which doesn't take negative numbers.

Resolves #51 