### PR TITLE
fix loading collisions from dff files

### DIFF
--- a/src/dffread.cpp
+++ b/src/dffread.cpp
@@ -76,7 +76,7 @@ namespace rw {
 		ColHeader fileHeader;
 		std::streamoff beginPos = rw.tellg();
 		rw.read((char*)&fileHeader, sizeof(fileHeader));
-		if (rw.gcount() == sizeof(fileHeader) && !strncmp(fileHeader.validator, "COL3", 4))
+		if (rw.gcount() == sizeof(fileHeader) && !strncmp(fileHeader.validator, "COL", 3))
 		{
 			rw.seekg(40, std::ios::cur);
 			if (ModelCount > 0)


### PR DESCRIPTION
fix error
"ColAndreas: Unable to load collision from given dff file (Corrupted data or no collision)."
when loading correct .dff files with collisions